### PR TITLE
Realguns update to fix Model 10

### DIFF
--- a/M_realguns/gun.json
+++ b/M_realguns/gun.json
@@ -17,7 +17,7 @@
     "dispersion": 360,
     "durability": 8,
     "clip_size": 7,
-    "magazines": [ [ "38", [ "38_speedloader" ] ] ]
+    "magazines": [ [ "38", [ "38_speedloader6" ] ] ]
   },
   {
     "id": "m6_asw",

--- a/M_realguns/magazine.json
+++ b/M_realguns/magazine.json
@@ -39,5 +39,5 @@
     "ammo_type": [ "38" ],
     "capacity": 6,
     "flags": [ "SPEEDLOADER" ]
-  },
+  }
 ]

--- a/M_realguns/magazine.json
+++ b/M_realguns/magazine.json
@@ -24,5 +24,20 @@
     "description": "A 9-round magazine for the M1991A1 .38 Super pistol.",
     "ammo_type": "38super",
     "capacity": 9
-  }
+  },
+  {
+    "id": "38_speedloader6",
+    "type": "MAGAZINE",
+    "name": ".38 6-round speedloader",
+    "description": "This speedloader can hold 6 rounds of .38 Special and quickly reload a compatible revolver such as the Model 10.",
+    "weight": "70 g",
+    "volume": "250 ml",
+    "price": 900,
+    "material": "steel",
+    "symbol": "#",
+    "color": "light_gray",
+    "ammo_type": [ "38" ],
+    "capacity": 6,
+    "flags": [ "SPEEDLOADER" ]
+  },
 ]


### PR DESCRIPTION
Added a 6-round .38 speedloader and set the Model 10 to use it, since it could not use the speedloader it was currently set to use due to a difference in capacities.