### PR TITLE
Update obsolete magazine in Modern Weapons Pack

### DIFF
--- a/Modern-Weapons-Pack-Expanded/modern_handgun/modern_handgun.json
+++ b/Modern-Weapons-Pack-Expanded/modern_handgun/modern_handgun.json
@@ -83,7 +83,7 @@
         [ "44", [ "deaglemag" ] ],
         [ "357_mag", [ "357_mag" ] ],
         [ "45", [ "m1911mag", "m1911bigmag" ] ],
-        [ "38", [ "taurus38mag" ] ]
+        [ "38", [ "taurus_spectrum_mag" ] ]
     ]
   },
   {


### PR DESCRIPTION
taurus38mag was obsoleted and replaced with taurus_spectrum_mag.